### PR TITLE
Use Redis authentication in Zabbix scripts if password is set

### DIFF
--- a/install/etc/zabbix/zabbix_agentd.conf.d/redis.conf
+++ b/install/etc/zabbix/zabbix_agentd.conf.d/redis.conf
@@ -1,9 +1,9 @@
 # total keys amount among all databases
-UserParameter=redis.keys,redis-cli info |grep -E -o 'keys=[0-9]+' |awk -F= '{sum += $2} END {print sum}'
+UserParameter=redis.keys,redis-cli${REDIS_PASS:+ -a "${REDIS_PASS}"} info |grep -E -o 'keys=[0-9]+' |awk -F= '{sum += $2} END {print sum}'
 
 # info statistics
-UserParameter=redis.stat[*],redis-cli info |grep -w $1 |cut -d: -f2
+UserParameter=redis.stat[*],redis-cli${REDIS_PASS:+ -a "${REDIS_PASS}"} info |grep -w $1 |cut -d: -f2
 
 # get raw data from redis
-UserParameter=redis.raw[*],redis-cli --raw $1 $2
+UserParameter=redis.raw[*],redis-cli${REDIS_PASS:+ -a "${REDIS_PASS}"} --raw $1 $2
 UserParameter=redis.discovery[*],/etc/zabbix/zabbix_agentd.conf.d/scripts/redis-discovery.sh $1 $2

--- a/install/etc/zabbix/zabbix_agentd.conf.d/scripts/redis-discovery.sh
+++ b/install/etc/zabbix/zabbix_agentd.conf.d/scripts/redis-discovery.sh
@@ -2,7 +2,7 @@
 # Author:   Lesovsky A.V.
 # Description:  Get values stored in Redis keys
 
-getValues=$(redis-cli --raw $1 $2)
+getValues=$(redis-cli${REDIS_PASS:+ -a "${REDIS_PASS}"} --raw $1 $2)
 
 echo -n '{"data":['
 for value in $getValues; do echo -n "{\"{#VALUE}\": \"$value\"},"; done |sed -e 's:\},$:\}:'


### PR DESCRIPTION
Modified the Zabbix scripts to include Redis authentication. This change ensures that scripts correctly authenticate with Redis servers that require a password. The password is only included if the REDIS_PASS variable is set and not empty.